### PR TITLE
Quando surgia uma imagem grande, o seu container estava empurrando o …

### DIFF
--- a/style.css
+++ b/style.css
@@ -13,8 +13,6 @@ html {
   flex-direction: column;
   justify-content: space-around;
   align-items: center;
-  width: 100vw;
-  height: 100vh;
   gap: 20px
 }
 
@@ -58,8 +56,8 @@ html {
 }
 
 .meme-container img {
-  max-height: 70%;
-  max-width: 100%;
+  min-height: 70%;
+  background-size: contain;
 }
 
 /* footer ul {


### PR DESCRIPTION
…question-container para cima, de forma que ele estava ficando inacessível ao tentar scrollar para cima. A solução foi deletar as linhas que estavam definindo um tamanho e largura fixos para o elemento de id container, e substituir o max-height da imagem para min-height